### PR TITLE
Update NXEngine to v1.0.0.6

### DIFF
--- a/nxengine/ai/final_battle/misery_finalbattle.cpp
+++ b/nxengine/ai/final_battle/misery_finalbattle.cpp
@@ -101,7 +101,7 @@ static void run_spells(Object *o)
 				o->timer = 0;
 				o->frame = 4;
 				
-				if (++o->timer >= 3)
+				if (++o->timer2 >= 3)
 				{
 					o->state = STATE_SUMMON_BLOCK;
 					o->timer2 = 0;

--- a/nxengine/intro/title.cpp
+++ b/nxengine/intro/title.cpp
@@ -247,7 +247,7 @@ static void draw_title()
 	draw_sprite(cx, acc_y, SPR_PIXEL_FOREVER);
 	
 	// version
-	static const char *VERSION = "NXEngine v. 1.0.0.4";
+	static const char *VERSION = "NXEngine v. 1.0.0.6";
 	static const int SPACING = 5;
 	int wd = GetFontWidth(VERSION, SPACING);
 	cx = (SCREEN_WIDTH / 2) - (wd / 2);


### PR DESCRIPTION
Just like the original source code, fixes a typo that caused Misery not to spawn falling blocks during Final Battle.