### PR TITLE
Fix compilation with DEBUG=1

### DIFF
--- a/nxengine/ai/sym/sym.cpp
+++ b/nxengine/ai/sym/sym.cpp
@@ -147,7 +147,7 @@ void ai_hvtrigger(Object *o)
 		game.switchstage.mapno == -1)	// no repeat exec after <TRA
 	{
 #ifdef DEBUG
-		stat("HVTrigger %04d (%08x) activated", o->id2, o);
+		NX_LOG("HVTrigger %04d (%08x) activated", o->id2, o);
 #endif
 		StartScript(o->id2);
 	}
@@ -1186,7 +1186,7 @@ void onspawn_spike_small(Object *o)
 	if (tileattr[tile] & TA_SOLID)
 	{
 #ifdef DEBUG
-		stat("onspawn_spike_small: spike %08x embedded in wall, deleting", o);
+		NX_LOG("onspawn_spike_small: spike %08x embedded in wall, deleting", o);
 #endif
 		o->Delete();
 	}

--- a/nxengine/common/StringList.cpp
+++ b/nxengine/common/StringList.cpp
@@ -5,6 +5,8 @@
 #include "StringList.h"
 #include "StringList.fdh"
 
+#include "../nx_logger.h"
+
 #ifdef _WIN32
 #include "../libretro/msvc_compat.h"
 #endif

--- a/nxengine/object.cpp
+++ b/nxengine/object.cpp
@@ -102,7 +102,7 @@ Object * const &o = this;
 	o->flags = (objprop[type].defaultflags & ~flags_to_keep) | keep;
 	
 #ifdef DEBUG
-	stat("new flags: %04x", o->flags);
+	NX_LOG("new flags: %04x", o->flags);
 #endif
 	
 	// setup default clipping extents, in case object turns on clip_enable


### PR DESCRIPTION
Fix missing include:
nxengine/common/StringList.cpp: In member function ‘void StringList::DumpContents()’:
nxengine/common/StringList.cpp:142:2: error: ‘NX_LOG’ was not declared

Fix undeclared reference (replace stat by NX_LOG):
nxengine/ai/sym/sym.o: In function `ai_hvtrigger(Object*)':
nx/nxengine/ai/sym/sym.cpp:150: undefined reference to `stat(char const*, ...)'
nxengine/ai/sym/sym.o: In function `onspawn_spike_small(Object*)':
nx/nxengine/ai/sym/sym.cpp:1189: undefined reference to `stat(char const*, ...)'
nxengine/object.o: In function `Object::SetType(int)':
nx/nxengine/object.cpp:105: undefined reference to `stat(char const*, ...)'