### PR TITLE
Log cleanup

### DIFF
--- a/nxengine/ai/first_cave/first_cave.cpp
+++ b/nxengine/ai/first_cave/first_cave.cpp
@@ -21,12 +21,10 @@ void ai_bat_up_down(Object *o)
 	switch(o->state)
 	{
 		case 0:
-         NX_LOG("ai_bat_up_down - state 0.\n");
 			o->ymark = o->y;
 			o->timer = random(0, 50);
 			o->state = 1;
 		case 1:
-         NX_LOG("ai_bat_up_down - state 1.\n");
 			if (!o->timer--)
 			{
 				o->state = 2;
@@ -35,7 +33,6 @@ void ai_bat_up_down(Object *o)
 		break;
 		
 		case 2:
-         NX_LOG("ai_bat_up_down - state 2.\n");
 		{
 			if (o->y >= o->ymark)
 				o->yinertia -= 0x10;

--- a/nxengine/ai/stdai.h
+++ b/nxengine/ai/stdai.h
@@ -6,10 +6,10 @@
 
 extern InitList AIRoutines;
 
-#define ONTICK(OBJTYPE, FUNCTION)		{ NX_LOG("Setting ONTICK to %p for type: %u.\n", FUNCTION, OBJTYPE);    objprop[OBJTYPE].ai_routines.ontick = FUNCTION; }
-#define ONDEATH(OBJTYPE, FUNCTION)		{ NX_LOG("Setting ONDEATH to %p for type: %u.\n", FUNCTION, OBJTYPE);   objprop[OBJTYPE].ai_routines.ondeath = FUNCTION; }
-#define AFTERMOVE(OBJTYPE, FUNCTION)	{ NX_LOG("Setting AFTERMOVE to %p for type: %u.\n", FUNCTION, OBJTYPE); objprop[OBJTYPE].ai_routines.aftermove = FUNCTION; }
-#define ONSPAWN(OBJTYPE, FUNCTION)		{ NX_LOG("Setting ONSPAWN to %p for type: %u.\n", FUNCTION, OBJTYPE);   objprop[OBJTYPE].ai_routines.onspawn = FUNCTION; }
+#define ONTICK(OBJTYPE, FUNCTION)		{ NX_DBG("Setting ONTICK to %p for type: %u.\n", FUNCTION, OBJTYPE);    objprop[OBJTYPE].ai_routines.ontick = FUNCTION; }
+#define ONDEATH(OBJTYPE, FUNCTION)		{ NX_DBG("Setting ONDEATH to %p for type: %u.\n", FUNCTION, OBJTYPE);   objprop[OBJTYPE].ai_routines.ondeath = FUNCTION; }
+#define AFTERMOVE(OBJTYPE, FUNCTION)	{ NX_DBG("Setting AFTERMOVE to %p for type: %u.\n", FUNCTION, OBJTYPE); objprop[OBJTYPE].ai_routines.aftermove = FUNCTION; }
+#define ONSPAWN(OBJTYPE, FUNCTION)		{ NX_DBG("Setting ONSPAWN to %p for type: %u.\n", FUNCTION, OBJTYPE);   objprop[OBJTYPE].ai_routines.onspawn = FUNCTION; }
 
 #define GENERIC_NPC(O)	\
 {	\

--- a/nxengine/extract-auto/cachefiles.cpp
+++ b/nxengine/extract-auto/cachefiles.cpp
@@ -495,7 +495,7 @@ bool cachefiles_init(FILE *exefp)
          continue;
       char fname[1024];
       retro_create_path_string(fname, sizeof(fname), g_dir, filenames[i]);
-      printf("%s\n", fname);
+      NX_DBG("%s\n", fname);
       FILE *f = fopen(fname, "rb");
       if (!f)
       {
@@ -538,7 +538,7 @@ bool cachefiles_init(FILE *exefp)
       HASH_FIND_STR(filemap, bmp_files[i].filename, entry);
       if (entry)
          continue;
-      printf("%s\n", bmp_files[i].filename);
+      NX_DBG("%s\n", bmp_files[i].filename);
       entry = (struct hash_struct *) calloc(sizeof(struct hash_struct), 1);
       if (!entry)
          continue;
@@ -556,7 +556,7 @@ bool cachefiles_init(FILE *exefp)
 
       if (strcmp(bmp_files[i].filename, "wavetable.dat") == 0)
       {
-         fprintf(stderr, "found wavetable.dat\n");
+         NX_DBG("found wavetable.dat\n");
          // wavetable.dat
          signed char *ptr = (signed char*)&entry->fd.data[0];
          int wav, sampl;
@@ -579,7 +579,6 @@ bool cachefiles_init(FILE *exefp)
 CFILE *copen(const char *fname, const char *mode)
 {
    (void)mode;
-   printf("copen %s\n", fname);
 
    // create local copy in case we have the same file open multiple times
    CFILE *f = (CFILE *)malloc(sizeof(CFILE));

--- a/nxengine/extract-auto/extractorg.cpp
+++ b/nxengine/extract-auto/extractorg.cpp
@@ -116,7 +116,7 @@ bool extract_org(FILE *exefp)
       fseek(exefp, files[i].offset, SEEK_SET);
       fread(file, files[i].length, 1, exefp);
 
-      fprintf(stderr, "file: %s\n", files[i].filename);
+      NX_DBG("file: %s\n", files[i].filename);
 
       // write out the file
       

--- a/nxengine/libretro/libretro.cpp
+++ b/nxengine/libretro/libretro.cpp
@@ -22,7 +22,7 @@ unsigned retro_frame_buffer_width;
 unsigned retro_frame_buffer_height;
 unsigned retro_frame_buffer_pitch;
 
-static retro_log_printf_t log_cb;
+retro_log_printf_t log_cb;
 static retro_video_refresh_t video_cb;
 static retro_input_poll_t poll_cb;
 retro_input_state_t input_cb;
@@ -375,10 +375,10 @@ void retro_init_saves()
             // Copy the file to the save directory only if it doesn't exist.
             if (!file_exists(savedirProfile)) {
                if (retro_copy_file(gamedirProfile, savedirProfile)) {
-                  printf("[nxengine] Copied profile %s to save directory at %s\n", gamedirProfile, savedirProfile);
+                  NX_LOG("Copied profile %s to save directory at %s\n", gamedirProfile, savedirProfile);
                }
                else {
-                  printf("[nxengine] Failed to copy profile %s to %s\n", gamedirProfile, savedirProfile);
+                  NX_ERR("Failed to copy profile %s to %s\n", gamedirProfile, savedirProfile);
                }
             }
          }
@@ -417,10 +417,10 @@ bool retro_copy_file(const char* from, const char* to)
       if (l2 < l1) {
          // Display an error message.
          if (ferror(fd2)) {
-            printf("[nxengine] Error copying profile from %s to %s\n", from, to);
+            NX_ERR("Error copying profile from %s to %s\n", from, to);
          }
          else {
-            printf("[nxengine] Error copying profile, media full from %s to %s\n", from, to);
+            NX_ERR("Error copying profile, media full from %s to %s\n", from, to);
          }
          return false;
       }
@@ -431,15 +431,17 @@ bool retro_copy_file(const char* from, const char* to)
 }
 
 #if defined(_MSC_VER) && _MSC_VER <= 1310
+
+#ifdef NDEBUG
+void NX_DBG(const char *fmt, ...)
+{
+}
+#endif
+
+#ifndef RELEASE_BUILD
 void NX_LOG(const char *fmt, ...)
 {
 }
+#endif
 
-void NX_WARN(const char *fmt, ...)
-{
-}
-
-void NX_ERR(const char *fmt, ...)
-{
-}
 #endif

--- a/nxengine/map.cpp
+++ b/nxengine/map.cpp
@@ -108,7 +108,7 @@ bool load_map(const char *fname)
 	}
 	else
 	{
-		printf("load_map: level size %dx%d\n", map.xsize, map.ysize);
+		NX_LOG("load_map: level size %dx%d\n", map.xsize, map.ysize);
 	}
 	
 	for(y=0;y<map.ysize;y++)

--- a/nxengine/nx_logger.h
+++ b/nxengine/nx_logger.h
@@ -17,97 +17,45 @@
 #ifndef __NX_LOGGER_H
 #define __NX_LOGGER_H
 
+#include <libretro.h>
+
+extern retro_log_printf_t log_cb;
+
+#ifndef NDEBUG
+#define  NX_DBG(...) do { \
+   if (log_cb) \
+      log_cb(RETRO_LOG_DEBUG, __VA_ARGS__); \
+   } while (0)
+#else
+#if defined(_MSC_VER) && _MSC_VER <= 1310
+void NX_DBG(const char *fmt, ...);
+#else
+#define NX_DBG(...)
+#endif
+#endif
+
 #ifdef RELEASE_BUILD
 #if defined(_MSC_VER) && _MSC_VER <= 1310
 void NX_LOG(const char *fmt, ...);
-void NX_WARN(const char *fmt, ...);
-void NX_ERR(const char *fmt, ...);
 #else
 #define NX_LOG(...)
-#define NX_ERR(...)
-#define NX_WARN(...)
 #endif
 #else
 
-#if defined(ANDROID) && defined(HAVE_LOGGER)
-#include <android/log.h>
-#endif
-
-#define LOG_FILE (stderr)
-
-#if defined(_XBOX1)
-#include "logger_override_xbox1.h"
-#else
-
-#ifndef NX_LOG
-#if defined(ANDROID) && defined(HAVE_LOGGER)
-#define  NX_LOG(...)  __android_log_print(ANDROID_LOG_INFO, "NX: ", __VA_ARGS__)
-#elif defined(_MSC_VER) && _MSC_VER <= 1310
-void NX_LOG(const char *fmt, ...);
-#else
-#define NX_LOG(...) do { \
-   fprintf(LOG_FILE, "NX: " __VA_ARGS__); \
-   fflush(LOG_FILE); \
+#define  NX_LOG(...) do { \
+   if (log_cb) \
+      log_cb(RETRO_LOG_INFO, __VA_ARGS__); \
    } while (0)
-#endif
+
 #endif
 
-#ifndef NX_LOG_OUTPUT
-#if defined(ANDROID) && defined(HAVE_LOGGER)
-#define  NX_LOG_OUTPUT(...)  __android_log_print(ANDROID_LOG_INFO,"stderr: ",__VA_ARGS__)
-#else
-#define NX_LOG_OUTPUT(...) do { \
-   fprintf(LOG_FILE, __VA_ARGS__); \
-   fflush(LOG_FILE); \
+#define  NX_WARN(...) do { \
+   if (log_cb) \
+      log_cb(RETRO_LOG_WARN, __VA_ARGS__); \
    } while (0)
-#endif
-#endif
-
-#ifndef NX_ERR
-#if defined(ANDROID) && defined(HAVE_LOGGER)
-#define  NX_ERR(...)  __android_log_print(ANDROID_LOG_INFO, "NX [ERROR] :: ", __VA_ARGS__)
-#else
-#define NX_ERR(...) do { \
-      fprintf(LOG_FILE, "NX [ERROR] :: " __VA_ARGS__); \
-      fflush(LOG_FILE); \
+#define  NX_ERR(...) do { \
+   if (log_cb) \
+      log_cb(RETRO_LOG_ERROR, __VA_ARGS__); \
    } while (0)
-#endif
-#endif
-
-#ifndef NX_ERR_OUTPUT
-#if defined(ANDROID) && defined(HAVE_LOGGER)
-#define  NX_ERR_OUTPUT(...)  __android_log_print(ANDROID_LOG_INFO, "stderr [ERROR] :: ", __VA_ARGS__)
-#else
-#define NX_ERR_OUTPUT(...) do { \
-      fprintf(LOG_FILE, "stderr [ERROR] :: " __VA_ARGS__); \
-      fflush(LOG_FILE); \
-   } while (0)
-#endif
-#endif
-
-#ifndef NX_WARN
-#if defined(ANDROID) && defined(HAVE_LOGGER)
-#define  NX_WARN(...)  __android_log_print(ANDROID_LOG_INFO, "NX [WARN] :: ", __VA_ARGS__)
-#else
-#define NX_WARN(...) do { \
-      fprintf(LOG_FILE, "NX [WARN] :: " __VA_ARGS__); \
-      fflush(LOG_FILE); \
-   } while (0)
-#endif
-#endif
-
-#ifndef NX_WARN
-#if defined(ANDROID) && defined(HAVE_LOGGER)
-#define  NX_WARN_OUTPUT(...)  __android_log_print(ANDROID_LOG_INFO, "stderr [WARN] :: ", __VA_ARGS__)
-#else
-#define NX_WARN_OUTPUT(...) do { \
-      fprintf(LOG_FILE, "stderr [WARN] :: " __VA_ARGS__); \
-      fflush(LOG_FILE); \
-   } while (0)
-#endif
-#endif
-#endif
-
-#endif
 
 #endif

--- a/nxengine/sdl/video/SDL_blit_0.c
+++ b/nxengine/sdl/video/SDL_blit_0.c
@@ -27,7 +27,7 @@
 #include "SDL_blit.h"
 
 #ifdef SDLPRINTF
-#define sdlprintf printf
+#define sdlprintf NX_LOG
 #else
 #define sdlprintf
 #endif

--- a/nxengine/tools/extractmapinfo.c
+++ b/nxengine/tools/extractmapinfo.c
@@ -58,7 +58,7 @@ char buf[256];
 	
 	// read data from exe
 	fp = fopen("/data/win/Programs/Games/Cave Story Deluxe/CaveStory/Doukutsu.exe", "rb");
-	if (!fp) { printf("Failed opening exe\n"); return 1; }
+	if (!fp) { NX_ERROR("Failed opening exe\n"); return 1; }
 	
 	// load raw data into struct
 	fseek(fp, DATA_OFFSET, SEEK_SET);


### PR DESCRIPTION
This patch should have little or no effect with the standard build flags, but when compiling without NDEBUG or RELEASE_BUILD the logging is hard to untangle, and in some case, excessive to the point of a noticeable loss in performance. This patch adds a NX_DBG call for the really trivial messages, and should replace any noticeable calls to `printf` to the log callback.