### PR TITLE
Return false at end of non-void function.

### DIFF
--- a/nxengine/main.cpp
+++ b/nxengine/main.cpp
@@ -248,6 +248,7 @@ loop:
 
 	game.stageboss.OnMapExit();
 	freshstart = false;
+	return false;
 }
 
 static inline void run_tick()


### PR DESCRIPTION
Fixes https://github.com/libretro/nxengine-libretro/issues/45 and https://github.com/libretro/nxengine-libretro/issues/51.

It may also fix https://github.com/libretro/nxengine-libretro/issues/50.

Please see this relevant warning printed by `gcc-8.2.0`.
```
nxengine/main.cpp: In function â..bool run_main()â..:
nxengine/main.cpp:250:13: warning: control reaches end of non-void function [-Wreturn-type]
  freshstart = false;
  ~~~~~~~~~~~^~~~~~~
```