### PR TITLE
Fix crash on PSP by using unrolled loop

### DIFF
--- a/nxengine/object.cpp
+++ b/nxengine/object.cpp
@@ -974,13 +974,17 @@ Object * const &o = this;
 void c------------------------------() {}
 */
 
-#ifdef _XBOX
+#if defined(_XBOX) || defined(PSP)
+#define AVOID_POINTER_TABLE
+#endif
+
+#ifdef AVOID_POINTER_TABLE
 #include "objfunc_ptrs.h"
 #endif
 
 void Object::OnTick()
 {
-#ifdef _XBOX
+#ifdef AVOID_POINTER_TABLE
    switch(type)
    {
       case OBJ_BAT_BLUE:
@@ -1897,7 +1901,7 @@ void Object::OnTick()
 
 void Object::OnAftermove()
 {
-#ifdef _XBOX
+#ifdef AVOID_POINTER_TABLE
    switch (type)
    {
       case OBJ_BLADE12_SHOT:
@@ -1967,7 +1971,7 @@ void Object::OnAftermove()
 
 void Object::OnSpawn()
 {
-#ifdef _XBOX
+#ifdef AVOID_POINTER_TABLE
    switch (type)
    {
       case OBJ_BALFROG:
@@ -2013,7 +2017,7 @@ void Object::OnSpawn()
 
 void Object::OnDeath()
 {
-#ifdef _XBOX
+#ifdef AVOID_POINTER_TABLE
    switch (type)
    {
       case OBJ_POLISH:

--- a/nxengine/sdl/video/SDL_blit.h
+++ b/nxengine/sdl/video/SDL_blit.h
@@ -251,6 +251,22 @@ static __inline void ALPHA_BLEND(int sR, int sG, int sB, const int A,
    *dB = (((sB - *dB) * A + 255) >> 8) + *dB;
 }
 
+/* 8-times unrolled loop */
+#define DUFFS_LOOP8(pixel_copy_increment, width)                        \
+{ int n = (width+7)/8;                                                  \
+    switch (width & 7) {                                                \
+    case 0: do {    pixel_copy_increment; /* fallthrough */             \
+    case 7:     pixel_copy_increment;     /* fallthrough */             \
+    case 6:     pixel_copy_increment;     /* fallthrough */             \
+    case 5:     pixel_copy_increment;     /* fallthrough */             \
+    case 4:     pixel_copy_increment;     /* fallthrough */             \
+    case 3:     pixel_copy_increment;     /* fallthrough */             \
+    case 2:     pixel_copy_increment;     /* fallthrough */             \
+    case 1:     pixel_copy_increment;     /* fallthrough */             \
+        } while ( --n > 0 );                                            \
+    }                                                                   \
+}
+
 /* Prevent Visual C++ 6.0 from printing out stupid warnings */
 #if defined(_MSC_VER) && (_MSC_VER >= 600)
 #pragma warning(disable: 4550)

--- a/nxengine/sdl/video/SDL_blit_1.c
+++ b/nxengine/sdl/video/SDL_blit_1.c
@@ -76,6 +76,21 @@ static void Blit1to2(SDL_BlitInfo *info)
    uint16_t *map = (uint16_t *)info->table;
    uint8_t *src  = info->s_pixels;
    uint8_t *dst  = info->d_pixels;
+#define USE_DUFFS_LOOP
+#ifdef USE_DUFFS_LOOP
+    while (height--) {
+        /* *INDENT-OFF* */
+        DUFFS_LOOP8(
+        {
+            *(uint16_t *)dst = map[*src++];
+            dst += 2;
+        },
+        width);
+        /* *INDENT-ON* */
+        src += srcskip;
+        dst += dstskip;
+    }
+#else
 
    /* Memory align at 4-byte boundary, if necessary */
    if ( (long)dst & 0x03 )
@@ -165,6 +180,7 @@ static void Blit1to2(SDL_BlitInfo *info)
          dst += dstskip;
       }
    }
+#endif /* USE_DUFFS_LOOP */
 }
 static void Blit1to3(SDL_BlitInfo *info)
 {


### PR DESCRIPTION
Using unrolled loop from 17af4584cb of SDL to fix crash on PSP