### PR TITLE
Adding diacritics support

### DIFF
--- a/nxengine/graphics/font.cpp
+++ b/nxengine/graphics/font.cpp
@@ -54,8 +54,8 @@ bool font_init(void)
 	SetColorKey(font, SDL_SRCCOLORKEY, 0);
 
 	error |= whitefont.InitChars(font, 0xffffff);
-	error |= greenfont.InitChars(font, 0x00ff80);
-	error |= bluefont.InitChars(font, 0xa0b5de);
+	error |= greenfont.InitChars(font, 0xffffff); // Workaround for avoiding diacritics to show in green color
+	error |= bluefont.InitCharsShadowed(font, 0xffffff, 0x000000); // Workaround for avoiding diacritics not showing on map location names
 	error |= shadowfont.InitCharsShadowed(font, 0xffffff, 0x000000);
 	error |= create_shade_sfc();
 

--- a/nxengine/graphics/font.h
+++ b/nxengine/graphics/font.h
@@ -3,7 +3,7 @@
 #define _FONT_H
 
 #define NUM_FONT_LETTERS		256
-#define NUM_LETTERS_RENDERED	128
+#define NUM_LETTERS_RENDERED	256 // Allow usage of the other half of the font, containing the diacritics
 #define FONT_DEFAULT_SPACING	5
 
 class NXFont

--- a/nxengine/map.cpp
+++ b/nxengine/map.cpp
@@ -837,7 +837,7 @@ void map_draw_map_name(void)
 {
 	if (game.showmapnametime)
 	{
-		font_draw(game.mapname_x, 84, map_get_stage_name(game.curmap), 0, &shadowfont);
+		font_draw(game.mapname_x, 84, map_get_stage_name(game.curmap), 0, &bluefont); // Workaround for avoiding diacritics not showing on map location names
 		game.showmapnametime--;
 	}
 }


### PR DESCRIPTION
This pull request allow usage of all the diacritics already existing in Libretro's bitmap font.

Originally, lr-nxengine can use only the first 128 characters of the game font, which has a total of 256 characters. Any attempts of using the characters of the other half of the font renders a blank space. You can see the font characters in the image below:

![Captura de tela de 2019-04-25 11-16-54](https://user-images.githubusercontent.com/5247082/56743610-463c2400-674d-11e9-8e83-0cdbe0dd3e66.png)

Since all diacritics are in the other half of the font, none of them are exhibited. This pull request basically increase the character font usage limit from 128 to 256 characters, thus solving the problem.

However, there are some caveats on this: Whenever any character of the other half of the font is used,  it uses a wrong font color. If you use white color, it changes to green instead. And if you use shadowed white color, the character disappears. To solve this, I had to deactivate the usage of both green and blue colors, drawing back to white / shadowed colors. Apart from that, everything seems to be working.