### PR TITLE
Add DOS target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -248,6 +248,13 @@ else ifeq ($(platform), xenon)
    AR = xenon-ar$(EXE_EXT)
    CFLAGS += -D__LIBXENON__ -D__ppc_ -DMSB_FIRST=1
 	STATIC_LINKING = 1
+else ifeq ($(platform), dos)
+   TARGET := $(TARGET_NAME)_libretro_djgpp.a
+   CC = i586-pc-msdosdjgpp-gcc$(EXE_EXT)
+   CXX = i586-pc-msdosdjgpp-g++$(EXE_EXT)
+   AR = i586-pc-msdosdjgpp-ar$(EXE_EXT)
+   STATIC_LINKING=1
+   STATIC_LINKING_LINK=1
 else ifeq ($(platform), ngc)
    TARGET := $(TARGET_NAME)_libretro_$(platform).a
    CC = $(DEVKITPPC)/bin/powerpc-eabi-gcc$(EXE_EXT)

--- a/nxengine/object.cpp
+++ b/nxengine/object.cpp
@@ -974,7 +974,7 @@ Object * const &o = this;
 void c------------------------------() {}
 */
 
-#if defined(_XBOX) || defined(PSP)
+#if defined(_XBOX) || defined(PSP) || defined(DJGPP)
 #define AVOID_POINTER_TABLE
 #endif
 


### PR DESCRIPTION
I'm a bit unsure if this is the intended way of building cores for DOS, however it works.
(Especially unsure if platform is "dos" or "djgpp")

For this core to work, long-file-names need to be supported by DOS. (i.e Windows 95 runs out-of-box when opened from Desktop)