### PR TITLE
Correctly handle input in inventory. Select weapon when exiting inventory.

### DIFF
--- a/nxengine/inventory.cpp
+++ b/nxengine/inventory.cpp
@@ -21,6 +21,7 @@ static stInventory inv;
 // param is passed as 1 when returning from Map System.
 bool inventory_init(int param)
 {
+   int oldarms = inv.armssel.cursel;
    memset(&inv, 0, sizeof(inv));
 
    inv.curselector = &inv.armssel;
@@ -31,6 +32,7 @@ bool inventory_init(int param)
    if (param == 1)
    {
       inv.curselector = &inv.itemsel;
+      inv.armssel.cursel = oldarms;
 
       // highlight Map System
       for(int i=0;i<inv.itemsel.nitems;i++)
@@ -298,12 +300,12 @@ static void RunSelector(stSelector *selector)
          inv.lockinput = 1;
       }
 
-      if (justpushed(FIREKEY))
+      if (justpushed(INVENTORYKEY) || justpushed(FIREKEY))
+      {
+         weapon_slide(LEFT, inv.armssel.items[inv.armssel.cursel]);
          ExitInventory();
+      }
    }
-
-   if (justpushed(INVENTORYKEY))
-      ExitInventory();
 }
 
 static void ExitInventory(void)

--- a/nxengine/inventory.cpp
+++ b/nxengine/inventory.cpp
@@ -310,7 +310,7 @@ static void ExitInventory(void)
 {
    StopScripts();
    game.setmode(GM_NORMAL);
-   memset(inputs, 0, sizeof(inputs));
+   player->inputs_locked = false;
 }
 
 static void DrawSelector(stSelector *selector, int x, int y)

--- a/nxengine/player.cpp
+++ b/nxengine/player.cpp
@@ -299,6 +299,7 @@ static unsigned inventory_delay = 0;
          {
             if (!game.frozen && !player->dead && GetCurrentScript() == -1)
             {
+               player->inputs_locked = true;
                game.setmode(GM_INVENTORY);
                inventory_delay = 15;
             }


### PR DESCRIPTION
The two commits are backports from nxengine-evo.

Without nxengine-evo, I wouldn't know what to do.

I tested the commits with my own system. The behavior of selecting weapons in the menu matches that of nxengine-evo and Cave Story Engine 2 used in Cave Story for Nintendo DS v0.3a by rain.

Now, selecting a machine gun in the menu by pressing fire fires machine gun in nxengine-evo, CSE 2, and nxengine-libretro. But, selecting other weapons in the menu by pressing fire doesn't fire the weapons.

This closes https://github.com/libretro/nxengine-libretro/issues/21