### PR TITLE
Close map system on fire, jump, or map button

### DIFF
--- a/nxengine/map_system.cpp
+++ b/nxengine/map_system.cpp
@@ -3,6 +3,7 @@
 #include "nx.h"
 #include "map_system.h"
 #include "map_system.fdh"
+#include "input.fdh"
 
 #define MS_EXPANDING		0
 #define MS_DISPLAYED		1
@@ -30,8 +31,6 @@ static struct
 	
 	const char *bannertext;
 	int textx, texty;
-	
-	bool lastbuttondown;
 } ms;
 
 
@@ -39,7 +38,6 @@ bool ms_init(int return_to_mode)
 {
 	memset(&ms, 0, sizeof(ms));
 	ms.return_gm = return_to_mode;
-	ms.lastbuttondown = true;
 	ms.w = map.xsize;
 	ms.h = map.ysize;
 	
@@ -109,12 +107,7 @@ void ms_tick(void)
 			Sprites::draw_sprite(ms.px, ms.py, SPR_MAP_PIXELS, 4);
 		
 		// dismissal
-		if (ms.lastbuttondown)
-		{
-			if (!buttondown())
-				ms.lastbuttondown = false;
-		}
-		else if (buttondown())
+		if (justpushed(FIREKEY) || justpushed(JUMPKEY) || justpushed(MAPSYSTEMKEY))
 		{
 			ms.state = MS_CONTRACTING;
 		}


### PR DESCRIPTION
This is based on d3a48db5da79ae10e0bae1470f53e4fd38d1cafd from nxengine-evo which also closes map system on those buttons.

With this, I probably picked up all low hanging fruits.

button press leaks out of map system if a button is still pressed after map system closes, but I don't know how nxengine-evo manages to lock inputs when it closes map system or options. Fortunately, it takes a while for map system to close.

For deeper changes, it would be easier to port nxengine-evo to libretro from scratch.

Forget about rebasing nxengine-libretro on nxengine-evo.
nxengine-libretro diverged too much from nxengine-evo.