### PR TITLE
Prevents inputs from leaking out of options mode, map system, and inventory.

### DIFF
--- a/nxengine/map_system.cpp
+++ b/nxengine/map_system.cpp
@@ -1,4 +1,4 @@
-
+/* vim: set shiftwidth=3 tabstop=3 textwidth=80 expandtab: */
 // the Map System
 #include "nx.h"
 #include "map_system.h"
@@ -56,7 +56,16 @@ bool ms_init(int return_to_mode)
 
 void ms_close(void)
 {
-	memset(inputs, 0, sizeof(inputs));
+   /*
+    * This prevents map system from leaking inputs to other modes and
+    * game player.
+    */
+   memcpy(lastpinputs, inputs, sizeof(lastpinputs));
+   /*
+    * This leaks inputs to other modes.
+    * How did nxengine-evo avoid leaking inputs to other modes with this?
+    */
+   /* memset(inputs, 0, sizeof(inputs)); */
 }
 
 

--- a/nxengine/p_arms.cpp
+++ b/nxengine/p_arms.cpp
@@ -1,4 +1,4 @@
-
+/* vim: set shiftwidth=3 tabstop=3 textwidth=80 expandtab: */
 #include "nx.h"
 #include "p_arms.fdh"
 
@@ -93,30 +93,34 @@ void PResetWeapons()
 
 void PDoWeapons(void)
 {
-	// switching weapons. have to check for inputs_frozen since justpushed
-	// reads inputs[] directly, not pinputs[].
-	if (!player->inputs_locked)
-	{
-		if (justpushed(PREVWPNKEY)) stat_PrevWeapon();
-		if (justpushed(NEXTWPNKEY)) stat_NextWeapon();
-	}
-	
-	// firing weapon
-	if (pinputs[FIREKEY])
-	{
-		FireWeapon();
-		RunWeapon(true);
-	}
-	else
-	{
-		RunWeapon(false);
-	}
-	
-	PHandleSpur();
-	run_whimstar(&player->whimstar);
-	
-	if (empty_timer)
-		empty_timer--;
+   static bool weapon_enabled = false;
+   // switching weapons. have to check for inputs_frozen since justpushed
+   // reads inputs[] directly, not pinputs[].
+   if (!player->inputs_locked)
+   {
+      if (justpushed(PREVWPNKEY)) stat_PrevWeapon();
+      if (justpushed(NEXTWPNKEY)) stat_NextWeapon();
+   }
+
+   // firing weapon
+   if (pinputs[FIREKEY])
+   {
+      if (!lastpinputs[FIREKEY])
+         weapon_enabled = true;
+      if (weapon_enabled)
+         FireWeapon();
+   }
+   else
+   {
+      weapon_enabled = false;
+   }
+   RunWeapon(weapon_enabled);
+
+   PHandleSpur();
+   run_whimstar(&player->whimstar);
+
+   if (empty_timer)
+      empty_timer--;
 }
 
 /*

--- a/nxengine/pause/options.cpp
+++ b/nxengine/pause/options.cpp
@@ -1,4 +1,4 @@
-
+/* vim: set shiftwidth=3 tabstop=3 textwidth=80 expandtab: */
 #include "../nx.h"
 #include "options.h"
 #include "dialog.h"
@@ -95,13 +95,17 @@ void options_tick()
 
 void DialogDismissed()
 {
-	if (opt.InMainMenu)
-	{
-		memset(inputs, 0, sizeof(inputs));
-		game.pause(false);
-	}
-	else
-		EnterMainMenu();
+   if (opt.InMainMenu)
+   {
+      game.pause(false);
+      /*
+       * This leaks inputs to other modes.
+       * How did nxengine-evo avoid leaking inputs to other modes with this?
+       */
+      /* memset(inputs, 0, sizeof(inputs)); */
+   }
+   else
+      EnterMainMenu();
 }
 
 void _60hz_change(ODItem *item, int dir)

--- a/nxengine/pause/pause.cpp
+++ b/nxengine/pause/pause.cpp
@@ -1,4 +1,4 @@
-
+/* vim: set shiftwidth=3 tabstop=3 textwidth=80 expandtab: */
 #include "../nx.h"
 #include "pause.fdh"
 
@@ -45,9 +45,3 @@ void pause_tick()
 		game.running = false;
 	}
 }
-
-
-
-
-
-

--- a/nxengine/player.cpp
+++ b/nxengine/player.cpp
@@ -1,4 +1,4 @@
-
+/* vim: set shiftwidth=3 tabstop=3 textwidth=80 expandtab: */
 #include "nx.h"
 #include "player.fdh"
 #include "inventory.h"
@@ -272,52 +272,45 @@ void PDoPhysics(void)
 
 void PUpdateInput(void)
 {
-int i;
-static unsigned inventory_delay = 0;
+   int i;
 
-	if (player->inputs_locked || player->disabled)
-	{
-		memset(pinputs, 0, sizeof(pinputs));
-	}
-	else
-	{
-		memcpy(pinputs, inputs, sizeof(pinputs));
-		
-		// prevent jumping/shooting when leaving a messagebox
-		if (player->inputs_locked_lasttime)
-		{
-			for(i=0;i<INPUT_COUNT;i++)
-				lastpinputs[i] |= pinputs[i];
-		}
+   if (player->inputs_locked || player->disabled)
+   {
+      memset(pinputs, 0, sizeof(pinputs));
+   }
+   else
+   {
+      memcpy(pinputs, inputs, sizeof(pinputs));
 
-      if (inventory_delay != 0)
-         inventory_delay--;
-      else
+      // prevent jumping/shooting when leaving a messagebox
+      if (player->inputs_locked_lasttime)
       {
-         // allow entering inventory
-         if (justpushed(INVENTORYKEY))
+         for(i=0;i<INPUT_COUNT;i++)
+            lastpinputs[i] |= pinputs[i];
+      }
+
+      // allow entering inventory
+      if (justpushed(INVENTORYKEY))
+      {
+         if (!game.frozen && !player->dead && GetCurrentScript() == -1)
          {
-            if (!game.frozen && !player->dead && GetCurrentScript() == -1)
+            player->inputs_locked = true;
+            game.setmode(GM_INVENTORY);
+         }
+      }
+
+      // Map System
+      if (justpushed(MAPSYSTEMKEY) && (FindInventory(ITEM_MAP_SYSTEM)!=-1))
+      {
+         if (!game.frozen && !player->dead && GetCurrentScript() == -1)
+         {
+            if (fade.getstate() == FS_NO_FADE && game.switchstage.mapno == -1)
             {
-               player->inputs_locked = true;
-               game.setmode(GM_INVENTORY);
-               inventory_delay = 15;
+               game.setmode(GM_MAP_SYSTEM, game.mode);
             }
          }
       }
-		
-		// Map System
-		if (justpushed(MAPSYSTEMKEY) && (FindInventory(ITEM_MAP_SYSTEM)!=-1))
-		{
-			if (!game.frozen && !player->dead && GetCurrentScript() == -1)
-			{
-				if (fade.getstate() == FS_NO_FADE && game.switchstage.mapno == -1)
-				{
-					game.setmode(GM_MAP_SYSTEM, game.mode);
-				}
-			}
-		}
-	}
+   }
 }
 
 


### PR DESCRIPTION
I don't understand how nxengine-evo manages to prevent inputs from leaking out of options mode, map system, and inventory with `memset(inputs, 0, sizeof(inputs))`.

By replacing `memset(inputs, 0, sizeof(inputs))` with `memcpy(lastpinputs, inputs, sizeof(lastpinputs))` in various places and enabling weapons only when `pinputs[FIREKEY]` is true and `lastpinputs[FIREKEY]` is false, I could prevent inputs from leaking out of options mode, map system, and inventory.

With these commits, pressing fire key to exit options mode, map system, or inventory doesn't trigger machine gun.
Even nxengine-evo and cave story engine 2 leak activate machine gun when I press fire key to exit options mode, map system, or inventory.

This fixes https://github.com/libretro/nxengine-libretro/issues/85