### PR TITLE
Fix textbox overflow

### DIFF
--- a/nxengine/graphics/font.cpp
+++ b/nxengine/graphics/font.cpp
@@ -278,9 +278,12 @@ static int text_draw(int x, int y, const char *text, int spacing, NXFont *font)
 		else
 		{	// variable spacing
 			if (ch == ' ' && shrink_spaces)
-			{	// 10.5 px for spaces - make smaller than they really are - the default
-				x += 6;
-				if (i & 1) x++;
+			{
+				/* This prevents various texts from overflowing textbox. */
+				x += 4;
+				/* 10.5 px for spaces - make smaller than they really are - the default */
+				/* x += 6; */
+				/* if (i & 1) x++; */
 			}
 			else
 			{


### PR DESCRIPTION
This fixes https://github.com/libretro/nxengine-libretro/issues/79

Before this pull request is applied,

![before](https://user-images.githubusercontent.com/748856/139800493-2c859c6d-c0d2-4300-a0e9-1b06635355a3.png)
![Doukutsu-211102-160313](https://user-images.githubusercontent.com/748856/139800700-504d5113-4a83-4f57-bfd5-67390f42a7b2.png)

After this pull request is applied,

![Doukutsu-211102-160737](https://user-images.githubusercontent.com/748856/139801170-6e21c65c-6855-4ee7-bd3f-d37e22e68add.png)
![Doukutsu-211102-160740](https://user-images.githubusercontent.com/748856/139801173-6c32a1b8-8e16-4fb5-be5c-ba0784096ba9.png)