### PR TITLE
Let GCC chose the proper march and mcpu flags for each Pi model

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -200,66 +200,14 @@ else ifeq ($(platform), ctr)
    STATIC_LINKING = 1
    SINGLE_PRECISION_FLOATS = 1
    MIN_AUDIO_PROCESSING_PER_FRAME = 1
-else ifeq ($(platform), rpi1)
+else ifeq ($(platform), rpi)
    TARGET := $(TARGET_NAME)_libretro.so
    fpic := -fPIC
    SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,-no-undefined
-   CFLAGS += -DARM -DGNU_SOURCE=1
-   CFLAGS += -marm -march=armv6j -mfpu=vfp -mfloat-abi=hard
-   CFLAGS += -fomit-frame-pointer -fstrict-aliasing
-   CFLAGS += -fno-exceptions
-   CXXFLAGS += -fno-rtti
+   CFLAGS += -DARM -DGNU_SOURCE=1 -fno-exceptions -march=native -mcpu=native -ftree-vectorize -pipe -fomit-frame-pointer 
+   CXXFLAGS := $(ASFLAGS) $(CFLAGS) -fno-rtti -fno-exceptions
    SINGLE_PRECISION_FLOATS = 1
    MIN_AUDIO_PROCESSING_PER_FRAME = 1
-   HAVE_NEON = 1
-else ifeq ($(platform), rpi2)
-   TARGET := $(TARGET_NAME)_libretro.so
-   fpic := -fPIC
-   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,-no-undefined
-   CFLAGS += -DARM -DGNU_SOURCE=1
-   CFLAGS += -marm -mcpu=cortex-a7 -mfpu=neon-vfpv4 -mfloat-abi=hard
-   CFLAGS += -fomit-frame-pointer -fstrict-aliasing
-   CFLAGS += -fno-exceptions
-   CXXFLAGS += -fno-rtti
-   SINGLE_PRECISION_FLOATS = 1
-   MIN_AUDIO_PROCESSING_PER_FRAME = 1
-   HAVE_NEON = 1
-else ifeq ($(platform), rpi3)
-   TARGET := $(TARGET_NAME)_libretro.so
-   fpic := -fPIC
-   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,-no-undefined
-   CFLAGS += -DARM -DGNU_SOURCE=1
-   CFLAGS += -marm -mcpu=cortex-a53 -mfpu=neon-fp-armv8 -mfloat-abi=hard
-   CFLAGS += -fomit-frame-pointer -fstrict-aliasing
-   CFLAGS += -fno-exceptions
-   CXXFLAGS += -fno-rtti
-   SINGLE_PRECISION_FLOATS = 1
-   MIN_AUDIO_PROCESSING_PER_FRAME = 1
-   HAVE_NEON = 1
-else ifeq ($(platform), rpi3_64)
-   TARGET := $(TARGET_NAME)_libretro.so
-   fpic := -fPIC
-   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,-no-undefined
-   CFLAGS += -DARM -DGNU_SOURCE=1
-   CFLAGS += -march=armv8-a+crc -mtune=cortex-a53
-   CFLAGS += -fomit-frame-pointer -fstrict-aliasing
-   CFLAGS += -fno-exceptions
-   CXXFLAGS += -fno-rtti
-   SINGLE_PRECISION_FLOATS = 1
-   MIN_AUDIO_PROCESSING_PER_FRAME = 1
-   HAVE_NEON = 1
-else ifeq ($(platform), rpi4_64)
-   TARGET := $(TARGET_NAME)_libretro.so
-   fpic := -fPIC
-   SHARED := -shared -Wl,--version-script=$(CORE_DIR)/libretro/link.T -Wl,-no-undefined
-   CFLAGS += -DARM -DGNU_SOURCE=1
-   CFLAGS += -march=armv8-a+crc+simd -mtune=cortex-a72
-   CFLAGS += -fomit-frame-pointer -fstrict-aliasing
-   CFLAGS += -fno-exceptions
-   CXXFLAGS += -fno-rtti
-   SINGLE_PRECISION_FLOATS = 1
-   MIN_AUDIO_PROCESSING_PER_FRAME = 1
-   HAVE_NEON = 1
 else ifeq ($(platform), xenon)
    TARGET := $(TARGET_NAME)_libretro_xenon360.a
    CC = xenon-gcc$(EXE_EXT)


### PR DESCRIPTION
Modern GCC can supply the right flags for each Pi model, no need for a chunk of ifeqs for that anymore.