### PR TITLE
There really should be an aspect_ratio member.

### DIFF
--- a/nxengine/libretro/libretro.cpp
+++ b/nxengine/libretro/libretro.cpp
@@ -181,9 +181,10 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.base_height = SCREEN_HEIGHT;
    info->geometry.max_width = SCREEN_WIDTH; 
    info->geometry.max_height = SCREEN_HEIGHT;
+   info->geometry.aspect_ratio = SCREEN_WIDTH/SCREEN_HEIGHT;
    info->timing.fps = 60.0;
    info->timing.sample_rate = 22050.0;
-   info->aspect_ratio = SCREEN_WIDTH/SCREEN_HEIGHT;
+
 }
 
 static void check_system_specs(void)

--- a/nxengine/libretro/libretro.cpp
+++ b/nxengine/libretro/libretro.cpp
@@ -183,6 +183,7 @@ void retro_get_system_av_info(struct retro_system_av_info *info)
    info->geometry.max_height = SCREEN_HEIGHT;
    info->timing.fps = 60.0;
    info->timing.sample_rate = 22050.0;
+   info->aspect_ratio = SCREEN_WIDTH/SCREEN_HEIGHT;
 }
 
 static void check_system_specs(void)


### PR DESCRIPTION
This is missing an aspect ratio member. This is vital for frontends that explicitly use it for scaling.