### PR TITLE
libretro: actually initialise the frontend VFS

### DIFF
--- a/nxengine/libretro/libretro.cpp
+++ b/nxengine/libretro/libretro.cpp
@@ -57,10 +57,26 @@ void retro_set_environment(retro_environment_t cb)
 
    environ_cb = cb;
 
-   vfs_iface_info.required_interface_version = 1;
+   /* Ask for a VFS new enough to cover path_is_valid() as well: the engine
+    * checks for its data files before opening them, and a frontend path
+    * (Android SAF, SMB) is not something stat() can resolve.
+    * Note that filestream_vfs_init() ignores anything below v2, so the
+    * previous v1 request left the core on plain stdio. */
+   vfs_iface_info.required_interface_version = PATH_REQUIRED_VFS_VERSION;
    vfs_iface_info.iface                      = NULL;
    if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
-	   filestream_vfs_init(&vfs_iface_info);
+   {
+      filestream_vfs_init(&vfs_iface_info);
+      path_vfs_init(&vfs_iface_info);
+   }
+   else
+   {
+      /* older frontend: take what it has, file streams only */
+      vfs_iface_info.required_interface_version = FILESTREAM_REQUIRED_VFS_VERSION;
+      vfs_iface_info.iface                      = NULL;
+      if (environ_cb(RETRO_ENVIRONMENT_GET_VFS_INTERFACE, &vfs_iface_info))
+         filestream_vfs_init(&vfs_iface_info);
+   }
 
    environ_cb(RETRO_ENVIRONMENT_SET_SUPPORT_NO_GAME, &no_content);
 }


### PR DESCRIPTION
Closes #110. The core asked for VFS interface version 1, but `filestream_vfs_init()` ignores anything below `FILESTREAM_REQUIRED_VFS_VERSION` (2) and returns without storing a single callback — so the whole engine, which already opens everything through `rfopen()`/`filestream_open()`, silently stayed on plain stdio. Android SAF URIs and `smb://` paths never reached the frontend.

It now asks for `PATH_REQUIRED_VFS_VERSION` (3) and initialises both the file streams and the path helpers, since the engine checks its data files with `path_is_valid()` before opening them and that check has to go through the same VFS (`file_path_io.c` is already in the build). A frontend that only offers v2 still gets the old behaviour — file streams only — through a second request.

Tested with a harness that hands the core a VFS whose paths are not real file paths, the way SAF URIs behave (`saf://…`, refusing anything the core tries to open outside the VFS): before the change `retro_load_game()` fails, after it `Doukutsu.exe`, every `data/` file, `settings.dat` and the profiles are opened through the VFS callbacks and the game runs, with no attempt to touch a path outside the VFS. Desktop behaviour is unchanged — RetroArch 1.22.2 logs `GET_VFS_INTERFACE. Core requested version >= V3, providing V3.` and Cave Story boots and runs at 60fps.